### PR TITLE
Kubernetes setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Docker is the recommended way to run the Synapse Server for those who do not wan
 To run the server on Docker, simply execute the following command in your system's shell:
 
 ```shell
-docker run --name synapse -v /var/run/docker.sock:/var/run/docker.sock -p 42286:42286 -p 41387:41387 ghcr.io/serverlessworkflow/synapse:latest
+docker run --name synapse -v /var/run/docker.sock:/var/run/docker.sock -p 42286:42286 -p 41387:41387 informaacr.azurecr.io/synapse/server:latest
 ```
 
 *Notes: you need to mount the `docker.sock` and/or run the container with the `--network host` option for Synapse to be able to spawn its own containers*

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - eventstore_data:/var/lib/eventstore
 
   synapse:
-    image: ghcr.io/serverlessworkflow/synapse:latest
+    image: informaacr.azurecr.io/synapse/server:latest
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - SYNAPSE_API_HOSTNAME=synapse

--- a/deployment/docker-compose/eventstore+mongo.yml
+++ b/deployment/docker-compose/eventstore+mongo.yml
@@ -27,7 +27,7 @@ services:
       - eventstore_data:/var/lib/eventstore
 
   synapse:
-    image: ghcr.io/serverlessworkflow/synapse:latest
+    image: informaacr.azurecr.io/synapse/server:latest
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - SYNAPSE_API_HOSTNAME=synapse

--- a/deployment/kubernetes/eventstore+mongo.yaml
+++ b/deployment/kubernetes/eventstore+mongo.yaml
@@ -127,8 +127,8 @@ spec:
       serviceAccountName: synapse
       containers:
         - name: synapse
-          image: ghcr.io/serverlessworkflow/synapse:latest
-          imagePullPolicy: IfNotPresent
+          image: informaacr.azurecr.io/synapse/server:latest
+          imagePullPolicy: Always
           env:
             - name: KUBERNETES_POD_NAME
               valueFrom:
@@ -138,6 +138,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: ASPNETCORE_ENVIRONMENT
+              value: Development
+            - name: SYNAPSE_SKIP_CERTIFICATE_VALIDATION
+              value: "true"
+            - name: SYNAPSE_PERSISTENCE_WRITEMODEL_DEFAULT_REPOSITORY
+              value: EventStore
+            - name: SYNAPSE_PERSISTENCE_READMODEL_DEFAULT_REPOSITORY
+              value: MongoDB
+            - name: CONNECTIONSTRINGS__EVENTSTORE
+              value: "esdb://event-store:2113?tls=false"
+            - name: CONNECTIONSTRINGS__MONGODB
+              value: mongodb://mongo:27017
 
 ---
 
@@ -149,6 +161,7 @@ metadata:
   labels: 
     app: synapse
 spec:
+  type: LoadBalancer
   ports:
     - name: http
       port: 42286

--- a/deployment/kubernetes/stand-alone.yaml
+++ b/deployment/kubernetes/stand-alone.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: synapse
       containers:
       - name: synapse
-        image: ghcr.io/serverlessworkflow/synapse:latest
+        image: informaacr.azurecr.io/synapse/server:1.0
         imagePullPolicy: IfNotPresent
         env:
           - name: KUBERNETES_POD_NAME

--- a/deployment/kubernetes/stand-alone.yaml
+++ b/deployment/kubernetes/stand-alone.yaml
@@ -35,8 +35,8 @@ spec:
       serviceAccountName: synapse
       containers:
       - name: synapse
-        image: informaacr.azurecr.io/synapse/server:1.0
-        imagePullPolicy: IfNotPresent
+        image: informaacr.azurecr.io/synapse/server:latest
+        imagePullPolicy: Always
         env:
           - name: KUBERNETES_POD_NAME
             valueFrom:

--- a/src/apps/Synapse.Cli/Commands/Systems/Installs/DockerInstallCommand.cs
+++ b/src/apps/Synapse.Cli/Commands/Systems/Installs/DockerInstallCommand.cs
@@ -69,7 +69,7 @@ namespace Synapse.Cli.Commands.Systems.Installs
             environmentVariables.Add(@$"-e ""{EnvironmentVariables.CloudEvents.Sink.Uri.Name} = {ceSink}""");
             if(skipCertificateValidation)
                 environmentVariables.Add(@$"-e ""{EnvironmentVariables.SkipCertificateValidation.Name} = {skipCertificateValidation}""");
-            var args = @$"run --name {name} -v /var/run/docker.sock:/var/run/docker.sock --add-host=host.docker.internal:host-gateway -p 42286:42286 -p 41387:41387 -d --restart unless-stopped {string.Join(" ", environmentVariables)} ghcr.io/serverlessworkflow/synapse:latest";
+            var args = @$"run --name {name} -v /var/run/docker.sock:/var/run/docker.sock --add-host=host.docker.internal:host-gateway -p 42286:42286 -p 41387:41387 -d --restart unless-stopped {string.Join(" ", environmentVariables)} informaacr.azurecr.io/synapse/server:latest";
             var process = Process.Start("docker", args);
             await process.WaitForExitAsync();
             await Task.Delay(500); //wait for the server to run

--- a/src/apps/Synapse.Server/Dockerfile
+++ b/src/apps/Synapse.Server/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 EXPOSE 42286 41387
 RUN apt-get update
 RUN apt-get install -y jq
+RUN apt-get -y install curl
 
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
@@ -27,15 +28,49 @@ COPY ["src/apis/management/Synapse.Apis.Management.Grpc/Synapse.Apis.Management.
 COPY ["src/apis/management/Synapse.Apis.Management.Grpc.Client/Synapse.Apis.Management.Grpc.Client.csproj", "src/apis/management/Synapse.Apis.Management.Grpc.Client/"]
 COPY ["src/dashboard/Synapse.Dashboard/Synapse.Dashboard.csproj", "src/dashboard/Synapse.Dashboard/"]
 COPY ["src/runtime/Synapse.Runtime.Native/Synapse.Runtime.Native.csproj", "src/runtime/Synapse.Runtime.Native/"]
+
+COPY ["src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/plugin.json", "src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/"]
+COPY ["src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj", "src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/"]
+
+COPY ["src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/plugin.json", "src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/"]
+COPY ["src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj", "src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/"]
+
+# Build Synapse.Server
 RUN dotnet restore "src/apps/Synapse.Server/Synapse.Server.csproj"
 COPY . .
 WORKDIR "/src/src/apps/Synapse.Server"
 RUN dotnet build "Synapse.Server.csproj" -c Release -o /app/build
 
+# Build Synapse.Plugins.Persistence.EventStore
+WORKDIR /src
+RUN dotnet restore "src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj"
+COPY . .
+WORKDIR "/src/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore"
+RUN dotnet build "Synapse.Plugins.Persistence.EventStore.csproj" -c Release -o /app/build/plugins/eventstore
+
+# Build Synapse.Plugins.Persistence.MongoDB
+WORKDIR /src
+RUN dotnet restore "src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj"
+COPY . .
+WORKDIR "/src/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB"
+RUN dotnet build "Synapse.Plugins.Persistence.MongoDB.csproj" -c Release -o /app/build/plugins/mongo
+
 FROM build AS publish
+
+# Publish Synapse.Server
+WORKDIR "/src/src/apps/Synapse.Server"
 RUN dotnet publish "Synapse.Server.csproj" -c Release -o /app/publish
+
+# Publish Synapse.Plugins.Persistence.EventStore
+WORKDIR "/src/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore"
+RUN dotnet publish "Synapse.Plugins.Persistence.EventStore.csproj" -c Release -o /app/publish/plugins/Synapse.Plugins.Persistence.EventStore
+
+# Publish Synapse.Plugins.Persistence.MongoDB
+WORKDIR "/src/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB"
+RUN dotnet publish "Synapse.Plugins.Persistence.MongoDB.csproj" -c Release -o /app/publish/plugins/Synapse.Plugins.Persistence.MongoDB
 
 FROM base AS final
 WORKDIR /app
-COPY --from=publish /app/publish .
+COPY --from=publish /app/publish/ .
+
 ENTRYPOINT ["dotnet", "Synapse.dll"]

--- a/src/apps/Synapse.Server/Synapse.Server.csproj
+++ b/src/apps/Synapse.Server/Synapse.Server.csproj
@@ -20,7 +20,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\..</DockerfileContext>
-    <DockerfileTag>ghcr.io/serverlessworkflow/synapse</DockerfileTag>
+    <DockerfileTag>informaacr.azurecr.io/synapse/server</DockerfileTag>
     <RuntimeIdentifiers>win10-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <AssemblyName>Synapse</AssemblyName>

--- a/src/apps/Synapse.Worker/Synapse.Worker.csproj
+++ b/src/apps/Synapse.Worker/Synapse.Worker.csproj
@@ -22,7 +22,7 @@
     <DebugType>embedded</DebugType>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..\..</DockerfileContext>
-    <DockerfileTag>ghcr.io/serverlessworkflow/synapse-worker</DockerfileTag>
+    <DockerfileTag>informaacr.azurecr.io/synapse/worker</DockerfileTag>
     <RuntimeIdentifiers>win10-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/Synapse.Plugins.Persistence.EventStore.csproj
@@ -32,11 +32,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Update="settings.plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/plugin.json
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.EventStore/plugin.json
@@ -7,6 +7,6 @@
   "copyright": "Copyright © 2022-Present The Synapse Authors. All Rights Reserved.",
   "licenseUri": "https://raw.githubusercontent.com/serverlessworkflow/synapse/main/LICENSE",
   "repositoryUri": "https://github.com/serverlessworkflow/synapse",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "assemblyFile": "Synapse.Plugins.Persistence.EventStore.dll"
 }

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/Synapse.Plugins.Persistence.MongoDB.csproj
@@ -32,11 +32,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Update="settings.plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="plugin.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
 </Project>

--- a/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/plugin.json
+++ b/src/plugins/persistence/Synapse.Plugins.Persistence.MongoDB/plugin.json
@@ -7,6 +7,6 @@
   "copyright": "Copyright © 2022-Present The Synapse Authors. All Rights Reserved.",
   "licenseUri": "https://raw.githubusercontent.com/serverlessworkflow/synapse/main/LICENSE",
   "repositoryUri": "https://github.com/serverlessworkflow/synapse",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "assemblyFile": "Synapse.Plugins.Persistence.MongoDB.dll"
 }

--- a/src/runtime/Synapse.Runtime.Docker/Configuration/DockerRuntimeOptions.cs
+++ b/src/runtime/Synapse.Runtime.Docker/Configuration/DockerRuntimeOptions.cs
@@ -29,7 +29,7 @@ namespace Synapse.Runtime.Docker.Configuration
         /// <summary>
         /// Gets the default Docker Runtime container image
         /// </summary>
-        public const string DefaultContainerImage = "ghcr.io/serverlessworkflow/synapse-worker";
+        public const string DefaultContainerImage = "informaacr.azurecr.io/synapse/worker";
 
         private static readonly Config _DefaultContainerConfiguration = new()
         {

--- a/src/runtime/Synapse.Runtime.Kubernetes/Configuration/KubernetesRuntimeOptions.cs
+++ b/src/runtime/Synapse.Runtime.Kubernetes/Configuration/KubernetesRuntimeOptions.cs
@@ -47,7 +47,7 @@ namespace Synapse.Runtime.Kubernetes.Configuration
                 {
                     new V1Container("synapse-worker")
                     {
-                        Image = $"ghcr.io/serverlessworkflow/synapse-worker:{typeof(KubernetesRuntimeOptions).Assembly.GetName().Version!.ToString(3)}",
+                        Image = $"informaacr.azurecr.io/synapse/worker:{typeof(KubernetesRuntimeOptions).Assembly.GetName().Version!.ToString(3)}",
                         ImagePullPolicy = "Always",
                         Ports = new List<V1ContainerPort>()
                         {


### PR DESCRIPTION
Initial k8s setup with persistence.
Use informaacr worker images instead of ghcr.io/serverlessworkflow images.